### PR TITLE
Add Ubuntu support

### DIFF
--- a/files/nohugepages.service
+++ b/files/nohugepages.service
@@ -3,7 +3,7 @@ Description=Disable Kernel Transparent Huge Pages
 
 [Service]
 Type=oneshot
-ExecStart=/usr/local/libexec/nohugepages.sh
+ExecStart=/usr/local/lib/nohugepages.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,9 +6,12 @@ galaxy_info:
   license: MIT
   min_ansible_version: 2.0.0
   platforms:
-  - name: EL
-    versions:
-    - 7
+    - name: EL
+      versions:
+      - 7
+    - name: Ubuntu
+      versions:
+      - xenial    
   galaxy_tags:
   - system
   - tweaks

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
     mode: "{{ item.mode }}"
   with_items:
     - src: "nohugepages.sh"
-      dest: "/usr/local/libexec/nohugepages.sh"
+      dest: "/usr/local/lib/nohugepages.sh"
       mode: "0755"
     - src: "nohugepages.service"
       dest: "/etc/systemd/system/nohugepages.service"


### PR DESCRIPTION
As far as I can tell the script works as-is on Ubuntu. The only problem is that the installation directory /usr/local/libexec doesn't exist on Ubuntu. This PR changes the installation directory to /usr/local/lib which is is found on both RHEL and Ubuntu.